### PR TITLE
Fix missing labels in WFCheckboxes.

### DIFF
--- a/phocoa/framework/widgets/WFCheckbox.php
+++ b/phocoa/framework/widgets/WFCheckbox.php
@@ -204,7 +204,7 @@ class WFCheckbox extends WFWidget
     {
         $myBindings = parent::setupExposedBindings();
         $myBindings[] = new WFBindingSetup('value', 'The value of the checkbox -- this will be either checkedValue or uncheckedValue depending on the checked status.');
-        $label = new WFBindingSetup('label', 'The label for the checkbox -- Text to label the checkbox with, or empty.');
+        $label = new WFBindingSetup('label', 'The label for the checkbox -- Text to label the checkbox with, or empty.', array(WFBinding::OPTION_VALUE_PATTERN => WFBindingSetup::WFBINDINGSETUP_PATTERN_OPTION_VALUE));
         $label->setBindingType(WFBindingSetup::WFBINDINGTYPE_MULTIPLE_PATTERN);
         $label->setReadOnly(true);
         $myBindings[] = $label;

--- a/phocoa/framework/widgets/WFLabel.php
+++ b/phocoa/framework/widgets/WFLabel.php
@@ -63,7 +63,7 @@ class WFLabel extends WFWidget
     {
         $myBindings = parent::setupExposedBindings();
         // do we need this custom binding setup here? wasn't WFBINDINGTYPE_MULTIPLE_PATTERN moved to WFView?
-        $newValBinding = new WFBindingSetup('value', 'The selected value for non-multiple select boxes.', array(WFBindingSetup::WFBINDINGSETUP_PATTERN_OPTION_NAME => WFBindingSetup::WFBINDINGSETUP_PATTERN_OPTION_VALUE));
+        $newValBinding = new WFBindingSetup('value', 'The selected value for non-multiple select boxes.', array(WFBindingSetup::WFBINDINGSETUP_PATTERN_OPTION_NAME => WFBinding::OPTION_VALUE_PATTERN_DEFAULT_PATTERN));
         $newValBinding->setReadOnly(true);
         $newValBinding->setBindingType(WFBindingSetup::WFBINDINGTYPE_MULTIPLE_PATTERN);
         $myBindings[] = $newValBinding;


### PR DESCRIPTION
They were missing if you didn't specify a ValuePattern.
