### PR TITLE
Fix "allErrors is not an object when trying to get next key 'errorMessage

### DIFF
--- a/phocoa/framework/WFError.php
+++ b/phocoa/framework/WFError.php
@@ -214,10 +214,15 @@ class WFErrorArray extends WFArray implements WFErrorCollection
         foreach ($this as $k => $v) {
             if (gettype($k) == 'integer')
             {
+                // We're assuming $v is a WFError
                 $flattenedErrors[] = $v;
             }
             else
             {
+                // We're assuming:
+                // 1) $k is the key that has WFErrors
+                // 2) $v is an array of WFErrors
+                if (!is_array($v)) throw new WFException('Expected an array of WFErrors.');
                 $flattenedErrors = array_merge($flattenedErrors, $v);
             }
         }


### PR DESCRIPTION
Fix "allErrors is not an object when trying to get next key 'errorMessage'" bug.

Wasn't able to reproduce this one because my production clone doesn't have the property in question.  Need to test this fix.
