### PR TITLE
Make an explicit assertion about how WFErrorArray is structured:

### DIFF
--- a/phocoa/framework/WFError.php
+++ b/phocoa/framework/WFError.php
@@ -214,10 +214,15 @@ class WFErrorArray extends WFArray implements WFErrorCollection
         foreach ($this as $k => $v) {
             if (gettype($k) == 'integer')
             {
+                // We're assuming $v is a WFError
                 $flattenedErrors[] = $v;
             }
             else
             {
+                // We're assuming:
+                // 1) $k is the key that has WFErrors
+                // 2) $v is an array of WFErrors
+                if (!is_array($v)) throw new WFException('Expected an array of WFErrors.');
                 $flattenedErrors = array_merge($flattenedErrors, $v);
             }
         }


### PR DESCRIPTION
WFErrorArray {
  1 => new WFError('General error'),
  2 => new WFError('General error'),
  'myKey' => array(
    1 => new WFError('Error for key'),
    2 => new WFError('Error for key'),
  ),
}

All general errors have integer keys in the root hash.  All specific errors have non-integer keys that point to an array of WFError objects.
