### PR TITLE
Protect against passing non-WFError objects into addErrorForKey

### DIFF
--- a/phocoa/framework/WFError.php
+++ b/phocoa/framework/WFError.php
@@ -279,6 +279,8 @@ class WFErrorArray extends WFArray implements WFErrorCollection
      */
     public function addErrorForKey($error, $key)
     {
+        if (!$error instanceof WFError) throw new Exception("Invalid error, expected WFError object");
+
         if (!isset($this[$key]))
         {
             $this[$key] = array();
@@ -452,6 +454,8 @@ class WFErrorsException extends WFException implements WFErrorCollection
      */
     public function addErrorForKey($error, $key)
     {
+        if (!$error instanceof WFError) throw new Exception("Invalid error, expected WFError object");
+
         if (!isset($this->errors[$key]))
         {
             $this->errors[$key] = array();

--- a/phocoa/framework/util/WFPropelIntegration.php
+++ b/phocoa/framework/util/WFPropelIntegration.php
@@ -59,6 +59,8 @@ class WFPropelException extends PropelException implements WFErrorCollection
      */
     public function addErrorForKey($error, $key)
     {
+        if (!$error instanceof WFError) throw new Exception("Invalid error, expected WFError object");
+
         $this->errors->addErrorForKey($error, $key);
         $this->message .= "{$error->errorMessage()} ";
         return $this;


### PR DESCRIPTION
Protect against passing non-WFError objects into [WFErrorArray,WFErrorsException,WFPropelException]->addErrorForKey.
