### PR TITLE
Add a sign up link to the log in page, specified by a delegate function

### DIFF
--- a/phocoa/RELEASE_NOTES
+++ b/phocoa/RELEASE_NOTES
@@ -10,6 +10,7 @@ Legend:
                               WF_LOG_DEPRECATED && WFLog::deprecated("MyObj::foo() is deprecated. Use MyObj::bar().");
 
 Version 0.4.1 - ??
+- [new] Log in module now supports WFAuthorization signUpURL() delegate function to provide a WFURL to a module that the end user can sign up on.
 
 Version 0.4.0 - 4/26/2011
 - [improved] Refactored WFErrorArray and WFErrorsException to implement a new interface WFErrorCollection.

--- a/phocoa/modules/login/login.php
+++ b/phocoa/modules/login/login.php
@@ -83,12 +83,17 @@ class login extends WFModule
             $this->gotoURL($continueURL);
         }
         
+        $signUpURL = NULL;
+        if (method_exists($ac->delegate(), 'signUpURL')) $signUpURL = $ac->delegate()->signUpURL();
+
         // continue to normal promptLogin setup
         $page->assign('loginMessage', $ac->loginMessage());
         $page->assign('usernameLabel', $ac->usernameLabel());
         $page->outlet('rememberMe')->setHidden( !$ac->shouldEnableRememberMe() );
         $page->outlet('forgottenPasswordLink')->setHidden( !$ac->shouldEnableForgottenPasswordReset() );
         $page->outlet('forgottenPasswordLink')->setValue( WFRequestController::WFURL('login', 'doForgotPassword') . '/' . $page->outlet('username')->value());
+        $page->outlet('signUpLink')->setHidden($signUpURL === NULL);
+        $page->outlet('signUpLink')->setValue($signUpURL);
 
         if (!$page->hasSubmittedForm())
         {

--- a/phocoa/modules/login/promptLogin.tpl
+++ b/phocoa/modules/login/promptLogin.tpl
@@ -19,7 +19,12 @@
         </tr>
         {/WFViewHiddenHelper}
         <tr>
-            <td colspan="2" align="center">{WFSubmit id="login"}</td>
+            <td colspan="2" align="center">
+                {WFSubmit id="login"}
+                {WFViewHiddenHelper id="signUpLink"}
+                    <span>or {WFLink id="signUpLink}</span>
+                {/WFViewHiddenHelper}
+            </td>
         </tr>
     </table>
 {/WFForm}

--- a/phocoa/modules/login/promptLogin.yaml
+++ b/phocoa/modules/login/promptLogin.yaml
@@ -14,8 +14,12 @@ loginForm:
       class: 'WFSubmit'
       properties: 
         action: 'doLogin'
-        label: 'Login'
+        label: 'Log In'
 forgottenPasswordLink: 
   class: 'WFLink'
   properties: 
     label: 'Forgot your password?'
+signUpLink:
+  class: 'WFLink'
+  properties:
+    label: 'Sign Up'


### PR DESCRIPTION
...(signUpURL() in WFAuthorization.

Is this the right place to do this?  It wasn't clear how WFAuthorizationInfo and the log in delegate work together.

Also, wouldn't it be better to allow applications to specify their own log in/log out pages?  Seems like you allow that currently but use the phocoa one by default.  Seems like as we're trying to improve conversions that we should move to our own views for these things.

-Jason
