### PR TITLE
Remove extra line break in WFLink that caused some links to have unneces...

### DIFF
--- a/phocoa/framework/widgets/WFLink.php
+++ b/phocoa/framework/widgets/WFLink.php
@@ -109,7 +109,8 @@ class WFLink extends WFWidget
             }
             $label = ($this->label !== NULL ? $this->label : $this->value);
             $title = ($this->title ? " title=\"{$this->title}\" " : NULL);
-            return "<a id=\"{$this->id}\" href=\"{$this->value}\" {$class}{$target}{$title}" . $this->getJSActions() . ">{$label}</a>\n" . $this->getListenerJSInScriptTag();
+            $listenerJs = ($this->getListenerJSInScriptTag() ? "\n{$this->getListenerJSInScriptTag()}" : '');
+            return "<a id=\"{$this->id}\" href=\"{$this->value}\" {$class}{$target}{$title}" . $this->getJSActions() . ">{$label}</a>{$listenerJs}";
         }
     }
 


### PR DESCRIPTION
...sary whitespace displayed after them.
