### PR TITLE
Update WFExceptionReporting.php

### DIFF
--- a/phocoa/framework/WFExceptionReporting.php
+++ b/phocoa/framework/WFExceptionReporting.php
@@ -16,7 +16,7 @@ class WFExceptionReporting extends WFObject
     /**
       * Log the passed exception to the framework's log folder.
       */
-    function log(Exception $e)
+    static function log(Exception $e)
     {
         $logfile = WFWebApplication::appDirPath(WFWebApplication::DIR_LOG) . '/framework_exceptions.log';
         $smarty = new WFSmarty();


### PR DESCRIPTION
Servers with strict parsing throw warning if used as static (which it is) but not declared as such.
