### PR TITLE
Fixed timeline "ago" vs "in"

### DIFF
--- a/phocoa/framework/widgets/WFFormatter.php
+++ b/phocoa/framework/widgets/WFFormatter.php
@@ -109,10 +109,14 @@ abstract class WFBaseDateFormatter extends WFFormatter
         return $formattedString;
     }
 
+    /**
+     * Converts a timestamp into a human readable relative time. E.g "in 2 days", "1 month ago", etc.
+     */
     public function relativeDate($time)
     {
         $today = strtotime(date('M j, Y'));
         $reldays = ($time - $today)/86400;
+
         if ($reldays >= 0 && $reldays < 1)
         {
             return 'Today';
@@ -125,6 +129,16 @@ abstract class WFBaseDateFormatter extends WFFormatter
         {
             return 'Yesterday';
         }
+
+
+        if ($reldays >= 0) {
+            $timelinePrefix = 'in ';
+            $timelineSuffix = '';
+        } else {
+            $timelinePrefix = '';
+            $timelineSuffix = ' ago';
+        }
+
 
         if (abs($reldays) < 7)
         {
@@ -142,17 +156,17 @@ abstract class WFBaseDateFormatter extends WFFormatter
         else if (abs($reldays) < 28)
         {
             $relweeks = abs(floor($reldays / 7));
-            return $relweeks . ' week'  . ($relweeks != 1 ? 's' : '') . ' ago';
+            return $timelinePrefix . $relweeks . ' week'  . ($relweeks != 1 ? 's' : '') . $timelineSuffix;
         }
         else if (abs($reldays) < 365)
         {
             $relmonths = abs(floor($reldays / 30));
-            return $relmonths . ' month'  . ($relmonths != 1 ? 's' : '') . ' ago';
+            return $timelinePrefix . $relmonths . ' month'  . ($relmonths != 1 ? 's' : '') . $timelineSuffix;
         }
         else
         {
             $relyears = abs(floor($reldays / 365));
-            return $relyears . ' year'  . ($relyears != 1 ? 's' : '') . ' ago';
+            return $timelinePrefix . $relyears . ' year'  . ($relyears != 1 ? 's' : '') . $timelineSuffix;
         }
 
         return date($this->relativeDateFormatString, $time ? $time : time());


### PR DESCRIPTION
@apinstein.
There was a schedule not showing properly in the prod system. The datetime was "10/16/2015" but the rel date was showing "1 month ago", instead of "in one month".

Let me know how this fix looks like.
I checked the WFFormatterTest, and some tests are failing, but seems to me the test do not reflect the current state of the formatter.

E.g, some tests expect that for an input "2006-01-01 11:59:59", the output will be the same. But since you introduced support for "years", those tests will never pass since that for a very old date the output will always come in "X years ago".

I'd get rid of those tests, unless you think we need to a different approach.