### PR TITLE
Master cleanup error handling alan

### DIFF
--- a/phocoa/framework/WFExceptionReporting.php
+++ b/phocoa/framework/WFExceptionReporting.php
@@ -5,7 +5,7 @@
  * @subpackage Error
  * @copyright Copyright (c) 2005 Alan Pinstein. All Rights Reserved.
  * @version $Id: kvcoding.php,v 1.3 2004/12/12 02:44:09 alanpinstein Exp $
- * @author Alan Pinstein <apinstein@mac.com>                        
+ * @author Alan Pinstein <apinstein@mac.com>
  */
 
 /**
@@ -14,16 +14,48 @@
 class WFExceptionReporting extends WFObject
 {
     /**
+     * Helper function to translate a PHP integer error code into the equivalent string.
+     *
+     * @param int PHP Error code (one of E_*)
+     * @return string
+     */
+    public static function phpErrorAsString($e)
+    {
+        // didn't use E_ERROR etc since they aren't all defined on all versions. it is a hard-coded hack, yes, but it works and won't change.
+        $el = array(
+            1     => 'E_ERROR',
+            2     => 'E_WARNING',
+            4     => 'E_PARSE',
+            8     => 'E_NOTICE',
+            16    => 'E_CORE_ERROR',
+            32    => 'E_CORE_WARNING',
+            64    => 'E_COMPILE_ERROR',
+            128   => 'E_COMPILE_WARNING',
+            256   => 'E_USER_ERROR',
+            512   => 'E_USER_WARNING',
+            1024  => 'E_USER_NOTICE',
+            2048  => 'E_STRICT',
+            4096  => 'E_RECOVERABLE_ERROR',
+            8192  => 'E_DEPRECATED',
+            16384 => 'E_USER_DEPRECATED',
+        );
+        return $el[$e];
+    }
+
+    /**
       * Log the passed exception to the framework's log folder.
+      *
+      * @param array Data from WFExceptionReporting::generatedStandardizedErrorDataFromException()
       */
-    function log(Exception $e)
+    public static function log($standardErrorData)
     {
         $logfile = WFWebApplication::appDirPath(WFWebApplication::DIR_LOG) . '/framework_exceptions.log';
+
         $smarty = new WFSmarty();
-        $smarty->assign('exception', $e);
+        $smarty->assign('standardErrorData', $standardErrorData);
         $smarty->setTemplate(WFWebApplication::appDirPath(WFWebApplication::DIR_SMARTY) . '/app_error_log.tpl');
         $errText = $smarty->render(false);
-        
+
         // append info to log
         $fs = fopen($logfile, 'a');
         fputs($fs, $errText);
@@ -39,15 +71,19 @@ class WFExceptionReporting extends WFObject
      * @return array A standardized array structure of all errors:
      *         [
      *              {
-     *                    'title'   => '',
-     *                    'message' => '',
-     *                    'code'    => '',
-     *                    'trace'   => ''
+     *                    'title'         => '',
+     *                    'message'       => '',
+     *                    'code'          => '',
+     *                    'traceAsString' => ''
+     *                    'trace'         => array( ... )
      *              }, ...
      *         ]
      */
     public static function generatedStandardizedErrorDataFromException(Exception $e)
     {
+        // grab error_get_last ASAP so that it cannot get adulterated by other things.
+        $lastPhpError = error_get_last();
+
         // build stack of errors (php 5.3+)
         if (method_exists($e, 'getPrevious'))
         {
@@ -64,24 +100,24 @@ class WFExceptionReporting extends WFObject
         $errorData = array();
         foreach ($allExceptions as $e) {
             $errorData[] = array(
-                'title'   => get_class($e),
-                'message' => $e->getMessage(),
-                'code'    => $e->getCode(),
-                'trace'   => array_merge(
+                'title'         => get_class($e),
+                'message'       => $e->getMessage(),
+                'code'          => $e->getCode(),
+                'traceAsString' => "At {$e->getFile()}:{$e->getLine()}\n" . preg_replace('/\(([0-9]+)\):/', ':\1', $e->getTraceAsString()),
+                'trace'         => array_merge(
                     array("At {$e->getFile()}:{$e->getLine()}"),
                     explode("\n", $e->getTraceAsString())
                 )
             );
         }
-        $lastErr = error_get_last();
-        if ($lastErr)
+        if ($lastPhpError)
         {
-            extract($lastErr);
             $errorData[] = array(
-                'title'   => "error_get_last(): most recent; may or may not be relevant.",
-                'message' => $message,
-                'code'    => $type,
-                'trace'   => "{$file}:{$line}"
+                'title'         => "error_get_last() at time error occurred; may or may not be relevant.",
+                'code'          => self::phpErrorAsString($lastPhpError['type']),
+                'message'       => $lastPhpError['message'],
+                'traceAsString' => "{$lastPhpError['file']}:{$lastPhpError['line']}",
+                'trace'         => array("{$lastPhpError['file']}:{$lastPhpError['line']}")
             );
         }
 

--- a/phocoa/framework/WFRequestController.php
+++ b/phocoa/framework/WFRequestController.php
@@ -5,7 +5,7 @@
  * @package WebApplication
  * @copyright Copyright (c) 2005 Alan Pinstein. All Rights Reserved.
  * @version $Id: kvcoding.php,v 1.3 2004/12/12 02:44:09 alanpinstein Exp $
- * @author Alan Pinstein <apinstein@mac.com>                        
+ * @author Alan Pinstein <apinstein@mac.com>
  */
 
 /**
@@ -45,36 +45,13 @@ class WFRequestController extends WFObject
      */
     private $handleErrors = 4597;
 
-    private function phpErrorAsString($e)
-    {
-        $el = array(
-            1     => 'E_ERROR',
-            2     => 'E_WARNING',
-            4     => 'E_PARSE',
-            8     => 'E_NOTICE',
-            16    => 'E_CORE_ERROR',
-            32    => 'E_CORE_WARNING',
-            64    => 'E_COMPILE_ERROR',
-            128   => 'E_COMPILE_WARNING',
-            256   => 'E_USER_ERROR',
-            512   => 'E_USER_WARNING',
-            1024  => 'E_USER_NOTICE',
-            2048  => 'E_STRICT',
-            4096  => 'E_RECOVERABLE_ERROR',
-            8192  => 'E_DEPRECATED',
-            16384 => 'E_USER_DEPRECATED',
-        );
-        return $el[$e];
-    }
-
     /**
      * Error handler callback for PHP catchable errors; helps synthesize PHP errors and exceptions into the same handling workflow.
      */
-    function handleError($errNum, $errString, $file, $line, $contextArray)
+    function handleError($severity, $message, $file, $line)
     {
-        $errNum = $this->phpErrorAsString($errNum);
-
-        $this->handleException( new ErrorException("{$errNum}: {$errString}\n\nAt {$file}:{$line}") );
+        $e = new ErrorException($message, 0, $severity, $file, $line);
+        $this->handleException($e);
     }
 
     /**
@@ -82,11 +59,11 @@ class WFRequestController extends WFObject
      */
     function checkShutdownForFatalErrors()
     {
+        // grab error_get_last ASAP so that it cannot get adulterated by other things.
         $last_error = error_get_last();
         if ($last_error['type'] & $this->handleErrors)
         {
-            $last_error['type'] = $this->phpErrorAsString($last_error['type']);
-            $this->handleException( new ErrorException("{$last_error['type']}: {$last_error['message']}\n\nAt {$last_error['file']}:{$last_error['line']}") );
+            $this->handleException( new ErrorException($last_error['message'], 0, $last_error['type'], $last_error['file'], $last_error['line']) );
         }
     }
 
@@ -120,6 +97,10 @@ class WFRequestController extends WFObject
         // give ourselves a little more memory so we can process the exception
         ini_set('memory_limit', memory_get_usage() + 25000000 /* 25MB */);
 
+        // grab error_get_last ASAP so that it cannot get adulterated by other things.
+        // we will inject it into things downstream that want it.
+        $standardErrorData = WFExceptionReporting::generatedStandardizedErrorDataFromException($e);
+
         // let the current module try to handle the exception
         if ($this->rootModuleInvocation)
         {
@@ -133,8 +114,11 @@ class WFRequestController extends WFObject
             if ($handled) return;
         }
 
-        WFExceptionReporting::log($e);
+        WFExceptionReporting::log($standardErrorData);
 
+        $exceptionPage = new WFSmarty();
+
+        // LEGACY tpl var setup (in case there are old .tpl's that expect it
         // build stack of errors (php 5.3+)
         if (method_exists($e, 'getPrevious'))
         {
@@ -148,15 +132,12 @@ class WFRequestController extends WFObject
         {
             $allExceptions = array($e);
         }
-
-
-        $exceptionPage = new WFSmarty();
         $exceptionPage->assign('exceptions', $allExceptions);
         $exceptionPage->assign('exceptionClass', get_class($allExceptions[0]));
         $exceptionPage->assign('home_url', WWW_ROOT . '/');
+        // end LEGACY
 
         // modern format
-        $standardErrorData = WFExceptionReporting::generatedStandardizedErrorDataFromException($e);
         $exceptionPage->assign('location', "http://{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}");
         $exceptionPage->assign('headline', "{$standardErrorData[0]['title']}: {$standardErrorData[0]['message']}");
         $exceptionPage->assign('standardErrorData', $standardErrorData);
@@ -166,7 +147,7 @@ class WFRequestController extends WFObject
             '$_REQUEST' => $_REQUEST,
             '$_SESSION' => $_SESSION,
         )));
-        // @todo refactor these templates to use WFExceptionReporting::generatedStandardizedErrorDataFromException($e)
+
         if (IS_PRODUCTION)
         {
             $exceptionPage->setTemplate(WFWebApplication::appDirPath(WFWebApplication::DIR_SMARTY) . '/app_error_user.tpl');
@@ -314,10 +295,10 @@ class WFRequestController extends WFObject
 
         $this->isMobileBrowser = strpos($ac, 'application/vnd.wap.xhtml+xml') !== false
                     || $op != ''
-                    || strpos($ua, 'sony') !== false 
-                    || strpos($ua, 'symbian') !== false 
-                    || strpos($ua, 'nokia') !== false 
-                    || strpos($ua, 'samsung') !== false 
+                    || strpos($ua, 'sony') !== false
+                    || strpos($ua, 'symbian') !== false
+                    || strpos($ua, 'nokia') !== false
+                    || strpos($ua, 'samsung') !== false
                     || strpos($ua, 'mobile') !== false
                     || strpos($ua, 'windows ce') !== false
                     || strpos($ua, 'epoc') !== false
@@ -427,7 +408,7 @@ class WFRequestController extends WFObject
 
 /**
  * Helper class to allow modules to easily redirect the client to a given URL.
- * 
+ *
  * Modules can throw a WFRedirectRequestException anytime to force the client to redirect.
  *
  * @deprecated
@@ -436,7 +417,7 @@ class WFRequestController extends WFObject
 class WFRedirectRequestException extends WFException
 {
     protected $redirectUrl;
-    
+
     function __construct($message = NULL, $code = 0)
     {
         parent::__construct($message, $code);

--- a/phocoa/smarty/templates/app_error_developer.tpl
+++ b/phocoa/smarty/templates/app_error_developer.tpl
@@ -1,59 +1,31 @@
 <h2>Uncaught Exception</h2>
-{foreach from=$exceptions item=exception}
-{php}
-    print "<table>
-            <tr>
-                <td>Class:</td>
-                <td>" . get_class($this->_tpl_vars['exception']) . "</td>
-            </tr>
-            <tr>
-                <td>Message:</td>
-                <td>{$this->_tpl_vars['exception']->getMessage()}</td>
-            </tr>
-            <tr>
-                <td>Code:</td>
-                <td>{$this->_tpl_vars['exception']->getCode()}</td>
-            </tr>
-            <tr>
-                <td>Location:</td>
-                <td>
-                    {$this->_tpl_vars['exception']->getFile()}:{$this->_tpl_vars['exception']->getLine()}
-                    <pre>Trace:\n" . $this->_tpl_vars['exceptions'][0]->getTraceAsString() . "</pre>
-                </td>
-            </tr>
-           </table>
-          "
-          ;
-{/php}
-{/foreach}
-{php}
-    extract(error_get_last());
-    print "
-          <h3>error_get_last() output</h3>
-          <p><em>may or may not be relevant to the Exception</em></p>
-          <table>
-            <tr>
-                <td>Type:</td>
-                <td>{$type}</td>
-            </tr>
-            <tr>
-                <td>Message:</td>
-                <td>{$message}</td>
-            </tr>
-            <tr>
-                <td>Location:</td>
-                <td>{$file}:{$line}</td>
-            </tr>
-           </table>
-          "
-          ;
-{/php}
 
-<h3>Server Data</h3>
-<pre>
-{php}
-print "
-URL: http://{$_SERVER['HTTP_HOST']}{$_SERVER["REQUEST_URI"]}
+<table>
+{foreach from=$standardErrorData item=error key=errorIndex}
+      <tr>
+        <th colspan=2>{$errorIndex+1}. {$error.title}</th>
+      </tr>
+      <tr>
+          <td>Message:</td>
+          <td>{$error.message}</td>
+      </tr>
+      <tr>
+          <td>Code:</td>
+          <td>{$error.code}</td>
+      </tr>
+      <tr>
+          <td>Location:</td>
+          <td>
+            <div class="phocoaStackTrace">{$error.traceAsString}</div>
+          </td>
+      </tr>
+{/foreach}
+</table>
+
+
+<h2>Server Data</h2>
+<div class="phocoaStackTrace">{php}
+print "URL: http://{$_SERVER['HTTP_HOST']}{$_SERVER["REQUEST_URI"]}
 Referrer: " . (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '(none)') . "
 Server: " . print_r($_SERVER, true) . "
 Request: " . print_r($_REQUEST, true) . "

--- a/phocoa/smarty/templates/app_error_log.tpl
+++ b/phocoa/smarty/templates/app_error_log.tpl
@@ -1,7 +1,11 @@
 ----------------------------------------------------------
 Date: {$smarty.now|date_format:'%A, %B %e, %Y %H:%M:%S'}
-Code: {$exception->getcode()}
-Message: {$exception->getMessage()}
-Stack Trace:
-{$exception->getTraceAsString()}
+{foreach name=errorDisplay from=$standardErrorData item=error key=errorIndex}
+{$errorIndex+1}. {$error.title}
+Message: {$error.message}
+Code: {$error.code}
+Location:
+{$error.traceAsString}
+
+{/foreach}
 ----------------------------------------------------------

--- a/phocoa/wwwroot/www/framework/phocoa.css
+++ b/phocoa/wwwroot/www/framework/phocoa.css
@@ -131,3 +131,9 @@ input[type=text].phocoaWFSpamHoneypot_input {
     border: none;
     visibility: hidden;
 }
+.phocoaStackTrace {
+  font-family: monospace;
+  white-space: pre;
+  width: 900px;
+  overflow: scroll;
+}


### PR DESCRIPTION
@leftdevel  I finished cleaning up that stuff we discussed today; thanks for the assistance.

1. phocoa logs all errors to framework_exception.log; I improved the formatting and refactored to the standard error data model, which added support for nested exceptions and error_get_last.

Example output:

```
--------------------------------------------------------------------------------------------------------------------
Date: Tuesday, January  5, 2016 22:00:50
1. Exception
Message: FOO
Code: 0
Location:
At /opt/www/domains/tourbuzz/releases/monolith/modules/public/pages/pages.php:21
#0 /opt/www/domains/tourbuzz/releases/monolith/vendor/apinstein/phocoa/phocoa/framework/WFPage.php:1728 module_pages_home->setupSkin(Object(WFPage), Array, Object(WFSkin))
#1 /opt/www/domains/tourbuzz/releases/monolith/vendor/apinstein/phocoa/phocoa/framework/WFPage.php:1592 WFPage->setupSkin(Object(WFSkin))
#2 /opt/www/domains/tourbuzz/releases/monolith/vendor/apinstein/phocoa/phocoa/framework/WFModule.php:409 WFPage->render()
#3 /opt/www/domains/tourbuzz/releases/monolith/vendor/apinstein/phocoa/phocoa/framework/WFRequestController.php:228 WFModuleInvocation->execute()
#4 /opt/www/domains/tourbuzz/releases/monolith/vendor/apinstein/phocoa/phocoa/framework/WFWebApplication.php:176 WFRequestController->handleHTTPRequest()
#5 /opt/www/domains/tourbuzz/releases/monolith/vendor/apinstein/phocoa/phocoa/framework/WFWebApplication.php:18 WFWebApplication->runWebApplication()
#6 /opt/www/domains/tourbuzz/releases/monolith/wwwroot/index.php:6 WFWebApplicationMain()
#7 {main}

2. error_get_last() at time error occurred; may or may not be relevant.
Message: file_get_contents(oscar://foo): failed to open stream: No such file or directory
Code: E_WARNING
Location:
/opt/www/domains/tourbuzz/releases/monolith/modules/public/pages/pages.php:20

----------------------------------------------------------
```

I also removed the `exit` that was killing rollbar (due to short-circuting shutdown function callbacks).

I also fixed up the styling of the developer error page.

<img width="1440" alt="screen shot 2016-01-05 at 11 05 47 pm" src="https://cloud.githubusercontent.com/assets/34889/12134792/e22385e2-b400-11e5-901b-83e15348de7a.png">

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/apinstein/phocoa/55)
<!-- Reviewable:end -->
