### PR TITLE
Put a try/catch around the web bootstrap process to ensure HTTP/500

### DIFF
--- a/phocoa/framework/bootstrap.php
+++ b/phocoa/framework/bootstrap.php
@@ -1,41 +1,53 @@
 <?php
 
 /**
- * PHOCOA has its own autoload infrastructure that is handled by WFWebApplication. So, this is the only require_once() we need to use in all PHOCOA framework code outside of bootstrapping this file.
+ * Use a try/catch around entire bootstrap process so we can ensure an http/500 on errors during bootstrapping.
+ *
+ * NOTE: this also gets called from CLI scripts, but it still works fine as header() is sanely ignored in non-HTTP SAPI.
+ * NOTE: this try/catch will miss "php fatal" errors, but those are very rare as a transient runtime error, and also go away in PHP7, so we are going to actively ignore that error path.
  */
-require('framework/util/WFIncluding.php');
-$ok = spl_autoload_register(array('WFIncluding', 'autoload'));
-if (!$ok) throw new WFException("Error registering WFIncluding::autoload()");
+try {
+    /**
+     * PHOCOA has its own autoload infrastructure that is handled by WFWebApplication. So, this is the only require_once() we need to use in all PHOCOA framework code outside of bootstrapping this file.
+     */
+    require('framework/util/WFIncluding.php');
+    $ok = spl_autoload_register(array('WFIncluding', 'autoload'));
+    if (!$ok) throw new WFException("Error registering WFIncluding::autoload()");
 
-// This version number should be updated with each release - this version number, among other things, is used to construct version-unique URLs for static resources
-// thus anytime anything in wwwroot/www/framework changes, this should be bumped. This version string should match [0-9\.]*
-define('PHOCOA_VERSION', '0.4.2');
-// PHOCOA shows all deprecation notices by default in wf.log on non-production hosts.
-if (!defined('WF_LOG_DEPRECATED'))
-{
-    define('WF_LOG_DEPRECATED', !IS_PRODUCTION);
-}
-
-if (!defined('WF_LOG_ENABLE_ERROR_REPORTING_AUTOCONFIGURATION') or WF_LOG_ENABLE_ERROR_REPORTING_AUTOCONFIGURATION)
-{
-    if (IS_PRODUCTION)
+    // This version number should be updated with each release - this version number, among other things, is used to construct version-unique URLs for static resources
+    // thus anytime anything in wwwroot/www/framework changes, this should be bumped. This version string should match [0-9\.]*
+    define('PHOCOA_VERSION', '0.4.2');
+    // PHOCOA shows all deprecation notices by default in wf.log on non-production hosts.
+    if (!defined('WF_LOG_DEPRECATED'))
     {
-        error_reporting(E_ALL);
-        ini_set('display_errors', false);
+        define('WF_LOG_DEPRECATED', !IS_PRODUCTION);
     }
-    else
-    {
-        error_reporting(E_ALL);
-        ini_set('display_errors', true);
-    }
-}
 
-require('framework/WFLog.php');    // need this for the PEAR_LOG_* constants below, which can't autoload.
-if (!defined('WF_LOG_LEVEL'))
-{
-    define('WF_LOG_LEVEL', IS_PRODUCTION ? PEAR_LOG_ERR : PEAR_LOG_DEBUG);
+    if (!defined('WF_LOG_ENABLE_ERROR_REPORTING_AUTOCONFIGURATION') or WF_LOG_ENABLE_ERROR_REPORTING_AUTOCONFIGURATION)
+    {
+        if (IS_PRODUCTION)
+        {
+            error_reporting(E_ALL);
+            ini_set('display_errors', false);
+        }
+        else
+        {
+            error_reporting(E_ALL);
+            ini_set('display_errors', true);
+        }
+    }
+
+    require('framework/WFLog.php');    // need this for the PEAR_LOG_* constants below, which can't autoload.
+    if (!defined('WF_LOG_LEVEL'))
+    {
+        define('WF_LOG_LEVEL', IS_PRODUCTION ? PEAR_LOG_ERR : PEAR_LOG_DEBUG);
+    }
+    // load the WFWebApplication so that it is initialized() before __autoload() is called for the first time.
+    // if we don't do this, classes attempted to autoload from WFWebApplication::initialize() will cause a fatal error.
+    require('framework/WFWebApplication.php');    // WFWebApplicationMain() can't autoload...
+    WFWebApplication::sharedWebApplication();
+} catch (Exception $e) {
+    header("HTTP/1.0 500 Uncaught Exception");
+    print "Uncaught Exception thrown during bootstrap.";
+    throw $e;
 }
-// load the WFWebApplication so that it is initialized() before __autoload() is called for the first time.
-// if we don't do this, classes attempted to autoload from WFWebApplication::initialize() will cause a fatal error.
-require('framework/WFWebApplication.php');    // WFWebApplicationMain() can't autoload...
-WFWebApplication::sharedWebApplication();


### PR DESCRIPTION
@leftdevel check it out!

1. I verified that no exception message details are shown when on production `ini_set('display_errors', false)`
2. I tested a php script as well... It does actually hit the code path we touched b/c scripts include `conf/webapp.conf` which bootstrapps the webapp but doesn't call the `main()` function which runs the request handler. However, the code we added works fine (it prints a bootstrap err msg and re-throws). The `header()` call is properly/silently ignored on non-HTTP SAPI's (per docs).

So I think this solves the immediate problem we discussed and will 100% prevent any *exceptions* during bootstrap from reporting as HTTP/200. FATAL errors would still be 200, but since that goes away in PHP7 and it's much more rare as a runtime error, I'm ok with that leak. I've commented that limitation.

If you think this looks fine, please merge!