### PR TITLE
support delegating log calls

### DIFF
--- a/phocoa/framework/WFLog.php
+++ b/phocoa/framework/WFLog.php
@@ -35,7 +35,7 @@ class WFLog extends WFObject
       */
     public static function log($message, $ident = 'general', $level = PEAR_LOG_DEBUG)
     {
-        $logger = self::getLogger($ident);
+        $logger = WFWebApplication::logger();
 
         if (!$logger) {
             if (!WFLog::logif($level)) return;   // bail as early as possible if we aren't gonna log this line
@@ -56,7 +56,7 @@ class WFLog extends WFObject
       */
     public static function logToFile($fileName, $message)
     {
-        $logger = self::getLogger($fileName);
+        $logger = WFWebApplication::logger();
 
         if (!$logger) {
             $logFileDir = WFWebApplication::sharedWebApplication()->appDirPath(WFWebApplication::DIR_LOG);
@@ -64,20 +64,6 @@ class WFLog extends WFObject
         }
 
         $logger->log(self::buildLogMessage($message));
-    }
-
-    /**
-    * Allow web application to define its own logging facade instead of relying on PEAR module.
-    */
-    public static function getLogger($channel)
-    {
-        $delegate = WFWebApplication::sharedWebApplication()->delegate();
-
-        if (method_exists($delegate, 'logger')) {
-            return $delegate->logger($channel);
-        }
-
-        return null;
     }
 
     public static function logif($level = PEAR_LOG_DEBUG)

--- a/phocoa/framework/WFLog.php
+++ b/phocoa/framework/WFLog.php
@@ -5,7 +5,7 @@
  * @subpackage Log
  * @copyright Copyright (c) 2005 Alan Pinstein. All Rights Reserved.
  * @version $Id: kvcoding.php,v 1.3 2004/12/12 02:44:09 alanpinstein Exp $
- * @author Alan Pinstein <apinstein@mac.com>                        
+ * @author Alan Pinstein <apinstein@mac.com>
  */
 
 /**
@@ -24,18 +24,18 @@ class WFLog extends WFObject
     const WARN_LOG = 'warn';
 
     /**
-      * Log the passed message to the framework's log folder.
-      * @param mixed string Log message to log.
-      *              object WFFunction A WFFunction which will be lazy-evaluated to produce the message to log. This level of decoupling allows the log infrastructure
-      *                                to be much faster when a message won't be logged as the message creation won't occur at all.
-      * @param string The "ident" of the message to log.
-      * @param level The PEAR log level (PEAR_LOG_EMERG, PEAR_LOG_ALERT, PEAR_LOG_CRIT, PEAR_LOG_ERR, PEAR_LOG_WARNING, PEAR_LOG_NOTICE, PEAR_LOG_INFO, and PEAR_LOG_DEBUG)
-      *
-      * The message will be logged to the wf.log file in the web application's log directory, if the log level is less than or equal to the WF_LOG_LEVEL.
-      */
+     * Log the passed message to the framework's log folder.
+     * @param mixed string Log message to log.
+     *              object WFFunction A WFFunction which will be lazy-evaluated to produce the message to log. This level of decoupling allows the log infrastructure
+     *                                to be much faster when a message won't be logged as the message creation won't occur at all.
+     * @param string The "ident" of the message to log.
+     * @param level The PEAR log level (PEAR_LOG_EMERG, PEAR_LOG_ALERT, PEAR_LOG_CRIT, PEAR_LOG_ERR, PEAR_LOG_WARNING, PEAR_LOG_NOTICE, PEAR_LOG_INFO, and PEAR_LOG_DEBUG)
+     *
+     * The message will be logged to the wf.log file in the web application's log directory, if the log level is less than or equal to the WF_LOG_LEVEL.
+     */
     public static function log($message, $ident = 'general', $level = PEAR_LOG_DEBUG)
     {
-        $logger = WFWebApplication::logger();
+        $logger = WFWebApplication::sharedWebApplication()->logger($ident);
 
         if (!$logger) {
             if (!WFLog::logif($level)) return;   // bail as early as possible if we aren't gonna log this line
@@ -48,15 +48,15 @@ class WFLog extends WFObject
     }
 
     /**
-      * Log the passed message to the framework's log folder in the filename specified.
-      * @param string The filename to log the message to. The exact string will be used for the filename; no extension will be appended.
-      * @param mixed string Log message to log.
-      *              object WFFunction A WFFunction which will be lazy-evaluated to produce the message to log. This level of decoupling allows the log infrastructure
-      *                                to be much faster when a message won't be logged as the message creation won't occur at all.
-      */
+     * Log the passed message to the framework's log folder in the filename specified.
+     * @param string The filename to log the message to. The exact string will be used for the filename; no extension will be appended.
+     * @param mixed string Log message to log.
+     *              object WFFunction A WFFunction which will be lazy-evaluated to produce the message to log. This level of decoupling allows the log infrastructure
+     *                                to be much faster when a message won't be logged as the message creation won't occur at all.
+     */
     public static function logToFile($fileName, $message)
     {
-        $logger = WFWebApplication::logger();
+        $logger = WFWebApplication::sharedWebApplication()->logger($fileName);
 
         if (!$logger) {
             $logFileDir = WFWebApplication::sharedWebApplication()->appDirPath(WFWebApplication::DIR_LOG);

--- a/phocoa/framework/WFLog.php
+++ b/phocoa/framework/WFLog.php
@@ -35,7 +35,7 @@ class WFLog extends WFObject
       */
     public static function log($message, $ident = 'general', $level = PEAR_LOG_DEBUG)
     {
-        $logger = self::getLogger();
+        $logger = self::getLogger($ident);
 
         if (!$logger) {
             if (!WFLog::logif($level)) return;   // bail as early as possible if we aren't gonna log this line
@@ -44,7 +44,7 @@ class WFLog extends WFObject
             $logger = Log::singleton('file', $logFileDir . '/wf.log', $ident, array('mode' => 0666), WF_LOG_LEVEL);
         }
 
-        $logger->log(self::buildLogMessage($message), $ident, $level);
+        $logger->log(self::buildLogMessage($message), $level);
     }
 
     /**
@@ -56,25 +56,25 @@ class WFLog extends WFObject
       */
     public static function logToFile($fileName, $message)
     {
-        $logger = self::getLogger();
+        $logger = self::getLogger($fileName);
 
         if (!$logger) {
             $logFileDir = WFWebApplication::sharedWebApplication()->appDirPath(WFWebApplication::DIR_LOG);
             $logger = Log::singleton('file', $logFileDir . '/' . $fileName, 'log', array('mode' => 0666));
         }
 
-        $logger->log(self::buildLogMessage($message), $fileName);
+        $logger->log(self::buildLogMessage($message));
     }
 
     /**
     * Allow web application to define its own logging facade instead of relying on PEAR module.
     */
-    public static function getLogger()
+    public static function getLogger($channel)
     {
         $delegate = WFWebApplication::sharedWebApplication()->delegate();
 
         if (method_exists($delegate, 'logger')) {
-            return $delegate->logger();
+            return $delegate->logger($channel);
         }
 
         return null;

--- a/phocoa/framework/WFWebApplication.php
+++ b/phocoa/framework/WFWebApplication.php
@@ -303,6 +303,23 @@ class WFWebApplication extends WFObject
     }
 
     /**
+     * Get the log delegate for a channel in the application.
+     *
+     * The logger delegate is provided by the {@link WFWebApplicationDelegate}.
+     *
+     * @param string The channel to scope the logger to
+     * @return object Object implementing the PEAR log interface, or NULL if there is no default delegate.
+     */
+    function logger($channel)
+    {
+        if (is_object($this->delegate) && method_exists($this->delegate, 'logger'))
+        {
+            return $this->delegate->logger($channel);
+        }
+        return NULL;
+    }
+
+    /**
      * Get the default Skin delegate for the application.
      *
      * The default skin delegate is provided by the {@link WFWebApplicationDelegate}.


### PR DESCRIPTION
Allow web application delegate to define own object for handling logs, assumes there is no distinction between file or non-file, and uses ident/file interchangeably as a key (ie: consumer can detect if key contains ".log" and do something differently)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apinstein/phocoa/61)
<!-- Reviewable:end -->
