### PR TITLE
WFDateTime throws exception if  is not a DateTimeZone object

### DIFF
--- a/phocoa/framework/widgets/yahoo/WFYAHOO_widget_DateTimePicker.php
+++ b/phocoa/framework/widgets/yahoo/WFYAHOO_widget_DateTimePicker.php
@@ -231,7 +231,7 @@ class WFYAHOO_widget_DateTimePicker extends WFYAHOO
                 }
                 else
                 {
-                    $tz = date_default_timezone_get();
+                    $tz = new DateTimeZone(date_default_timezone_get());
                 }
             }
             else


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apinstein/phocoa/62)
<!-- Reviewable:end -->
